### PR TITLE
param for making dependencies optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,15 @@
 class zf(
-  $ensure     = $zf::params::ensure,
-  $version    = $zf::params::version,
-  $installdir = $zf::params::zenddir,
-  $zftool     = $zf::params::zftool,
+  $ensure      = $zf::params::ensure,
+  $version     = $zf::params::version,
+  $installdir  = $zf::params::zenddir,
+  $zftool      = $zf::params::zftool,
+  $manage_deps = $zf::params::manage_deps,
 ) inherits zf::params {
 
-	include zf::dependencies
+  if $manage_deps {
+    include zf::dependencies
+  }
+
 	case $ensure {
 		'present': {
 			case $version {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,11 @@
 class zf::params
 {
-	$ensure  			= "present"
-	$version 			= "1.12.3"
-	$srcdir  			= "/usr/src"
-	$peardir 			= "/usr/share/php"
-	$zenddir 			= "/usr/share/ZendFramework"
-	$toolbin 			= "/usr/bin/zf"
-	$zftool  			= false
-	$manage_deps  = true
+  $ensure      = "present"
+  $version     = "1.12.3"
+  $srcdir      = "/usr/src"
+  $peardir     = "/usr/share/php"
+  $zenddir     = "/usr/share/ZendFramework"
+  $toolbin     = "/usr/bin/zf"
+  $zftool      = false
+  $manage_deps = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,10 +1,11 @@
 class zf::params
 {
-	$ensure  = "present"
-	$version = "1.12.3"
-	$srcdir  = "/usr/src"
-	$peardir = "/usr/share/php"
-	$zenddir = "/usr/share/ZendFramework"
-	$toolbin = "/usr/bin/zf"
-	$zftool  = false
+	$ensure  			= "present"
+	$version 			= "1.12.3"
+	$srcdir  			= "/usr/src"
+	$peardir 			= "/usr/share/php"
+	$zenddir 			= "/usr/share/ZendFramework"
+	$toolbin 			= "/usr/bin/zf"
+	$zftool  			= false
+	$manage_deps  = true
 }


### PR DESCRIPTION
It’s now possible to make dependencies optional. This could prevent
duplicate declarations of pear package or php package if there are other modules to
manage them.